### PR TITLE
Globally disable the Style/FormatStringToken cop

### DIFF
--- a/config/other-excludes.yml
+++ b/config/other-excludes.yml
@@ -11,3 +11,6 @@ Metrics/BlockLength:
 
 Bundler/DuplicatedGem:
   Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false


### PR DESCRIPTION
- In recent versions of Rubocop, this cop has appeared and it's raising
  linting issues on a load of our repos.
- The wording of the description is hard to understand - it's not
  immediately obvious what you have to do, and doesn't really say why
  this is a good thing. The
  [docs](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/FormatStringToken)
  are also not very explanatory.
- I made some misguided attempts to fix these errors - having not
  understood the required syntax or purpose - in smart-answers
  and lost a lot of time that I could have spent elsewhere.
- It's not auto-fixable, which means it takes a lot of time to get the
  syntax right for every occurrence of `%.2f` for example (taken from
  `smart-answers`) for not very much benefit.

--- 

Examples of the linting issues this raises: [maslow](https://ci.integration.publishing.service.gov.uk/job/maslow/job/dependabot%252Fbundler%252Fgovuk-lint-4.1.0/1/console), [local-links-manager](https://ci.integration.publishing.service.gov.uk/job/local-links-manager/job/dependabot%252Fbundler%252Fgovuk-lint-4.1.0/1/console), [whitehall](https://ci.integration.publishing.service.gov.uk/job/whitehall/job/dependabot%252Fbundler%252Fgovuk-lint-4.1.0/1/console).