### PR TITLE
Refactor config to seperate ruby and rails rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-inherit_from: ./config/all.yml
+inherit_from:
+  - ./config/default.yml
+  - ./config/rails.yml
 
 AllCops:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow importing of Ruby and Rails rules seperately
+
 # 0.2.0
 
 * Disable the Style/FormatStringToken cop

--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ Inherit rules from the gem by adding the following to your project's RuboCop con
 ```yaml
 # .rubocop
 inherit_gem:
-  rubocop-govuk: config/all.yml
+  rubocop-govuk: 
+    - config/default.yml
+```
+
+or if you also need Rails specific rules:
+
+```yaml
+# .rubocop
+inherit_gem:
+  rubocop-govuk: 
+    - config/default.yml
+    - config/rails.yml
 ```
 
 ## Usage

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,12 +11,9 @@ AllCops:
     Description: 'Display style guide URLs in offense messages.'
     Enabled: true
 
-require: rubocop-rails
-
 inherit_from:
   - gds-ruby-styleguide.yml
   - other-lint.yml
-  - other-rails.yml
   - other-style.yml
   - other-metrics.yml
   - other-excludes.yml

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -2,8 +2,11 @@
 
 # By default Rails is switched off so this can be used by non-Rails apps,
 # this can be enabled in a local .rubocop.yml file
+
+require: rubocop-rails
+
 Rails:
-  Enabled: false
+  Enabled: true
 
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'


### PR DESCRIPTION
This is for Ruby only projects where Rails rules should not be inherited. Rails projects now need to explicitly inherit Rails rubocop rules.