### PR TITLE
Fix RuboCop version specificity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0
+
+* Use specific version for RuboCop
+* Update RuboCop to 0.77
+
 # 1.0.0
 
 * Allow importing of Ruby and Rails rules seperately

--- a/config/gds-ruby-styleguide.yml
+++ b/config/gds-ruby-styleguide.yml
@@ -114,7 +114,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # Supports --auto-correct
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: Checks trailing blank lines and final newline.
   Enabled: true
   EnforcedStyle: final_newline
@@ -245,7 +245,7 @@ Style/TrivialAccessors:
   ExactNameMatch: true
   AllowPredicates: true
   AllowDSLWriters: false
-  Whitelist:
+  AllowedMethod:
   - to_ary
   - to_a
   - to_c
@@ -282,7 +282,7 @@ Lint/RescueException:
 ## Collections
 
 # Supports --auto-correct
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: Align the elements of an array literal if they span more than one line.
   Enabled: true
 
@@ -323,7 +323,7 @@ Layout/MultilineMethodCallIndentation:
 ## Strings
 
 # Supports --auto-correct
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Description: Checks for Object#to_s usage in string interpolation.
   Enabled: true
 

--- a/config/other-lint.yml
+++ b/config/other-lint.yml
@@ -46,7 +46,7 @@ Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: "Don't suppress exception."
   Enabled: true
 

--- a/config/other-style.yml
+++ b/config/other-style.yml
@@ -11,13 +11,13 @@ Style/Alias:
   Description: 'Use alias_method instead of alias.'
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Description: >-
     Align the elements of a hash literal if they span more than
     one line.
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: >-
     Align the parameters of a method call if they span more
     than one line.
@@ -168,13 +168,13 @@ Style/IfWithSemicolon:
   Description: 'Never use if x; .... Use the ternary operator instead.'
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Description: >-
     Checks the indentation of the first element in an array
     literal.
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: false
 

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 12.0"
 
-  spec.add_dependency "rubocop", "~> 0.76"
+  spec.add_dependency "rubocop", "0.76"
   spec.add_dependency "rubocop-rails", "~> 2"
   spec.add_dependency "rubocop-rspec", "~> 1.28"
 end

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 12.0"
 
-  spec.add_dependency "rubocop", "0.76"
+  spec.add_dependency "rubocop", "0.77"
   spec.add_dependency "rubocop-rails", "~> 2"
   spec.add_dependency "rubocop-rspec", "~> 1.28"
 end

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "1.0.0"
+  spec.version       = "2.0.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
As RuboCop can introduce breaking changes in a minor release, we need to specify the minor version number in our dependencies to provide stability.

This PR includes the following changes:

- Use a specific minor version of RuboCop
- Update RuboCop dependency to latest version
- Bump version to 2.0.0 (as RuboCop update is a breaking change)

