### PR TITLE
Exclude `bin` directory and `db/schema.rb` from linting for every app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Update Rubocop to 0.79
+* Exclude `bin` directory and `db/schema.rb` from linter checks
 
 # 2.0.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,7 @@
 AllCops:
+  Excludes:
+    - 'bin/**'
+
   DisplayCopNames:
     Description: 'Display cop names in offense messages'
     Enabled: true

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -5,6 +5,10 @@
 
 require: rubocop-rails
 
+AllCops:
+  Exclude:
+    - 'db/schema.rb'
+
 Rails:
   Enabled: true
 


### PR DESCRIPTION
- At the moment, `govuk-jenkinslib` runs RuboCop on [certain directories](https://github.com/alphagov/govuk-jenkinslib/blob/7ed1f44a379a48de6a2beb371e94c9ef920d6fb0/vars/govuk.groovy#L175).
- At the moment, apps have to scope their `bundle exec rubocop` runs to the same directories for local development consistency, or set `rubyLintDirs` to a different set of directories so that Jenkins runs them. They used to have `lint` Rake tasks, but in the interests of consistency and speed (some apps ran linting checks twice on CI, and some apps didn't have a lint Rake task at all), they were [recently mostly deleted](https://trello.com/c/70SfiMDa/133-move-the-rubocop-only-lint-certain-directories-choice-into-rubocop-govuk-from-govuk-jenkinslib).
- This is not at all obvious to developers looking to fix _all RuboCop errors_ in apps they use if they don't know about the Jenkins scoping, and can lead to extra work that CI will never test.
- As part of the GOV.UK Developer Tooling working group's linting epic (https://trello.com/c/nEHfEd1H/127-standardize-linting-infra-rake-tasks-jenkinsfile-ci), this is part _n_ of putting all linting config in one place.
- Rather than `Include`ing all the directories that a Rails app might use (`app`, `spec`, `lib`, `test`, `features`), the `Exclude` list here is a lot more succinct. Files in `bin` are auto-generated, usually, and as are files in `config/`.

https://trello.com/c/70SfiMDa/133-move-the-rubocop-only-lint-certain-directories-choice-into-rubocop-govuk-from-govuk-jenkinslib