### PR TITLE
Bump version to 3.0.0 after merging #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# Unreleased
+# 3.0.0
 
-* Update Rubocop to 0.79
-* Exclude `bin` directory and `db/schema.rb` from linter checks
+* Update Rubocop to 0.80.1
+  * This deletes the Style/BracesAroundHashParameters cop for future
+    Ruby 3 compatibility.
+* Exclude `bin` directory and `db/schema.rb` from linter checks (#14)
 
 # 2.0.0
 

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "2.0.0"
+  spec.version       = "3.0.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
- This is a breaking change as it changes behaviour of running `rubocop`
  in an app to only run against some directories.