### PR TITLE
Fix deprecation warning caused by config/default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,5 @@
 AllCops:
-  Excludes:
+  Exclude:
     - 'bin/**'
 
   DisplayCopNames:


### PR DESCRIPTION
`AllCops/Excludes` works but causes a deprecation warning saying it was renamed to `AllCops/Exclude`. We bumped into this during the upgrade to `3.0.0` (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1525)