### PR TITLE
Exclude `config.ru` from RuboCop linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix deprecation warning for AllCops/Excludes => AllCops/Exclude (#17)
+* Exclude `config.ru` from linter checks (#18)
 
 # 3.0.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'bin/**'
+    - 'config.ru'
 
   DisplayCopNames:
     Description: 'Display cop names in offense messages'


### PR DESCRIPTION
- These are generated files that we shouldn't be editing for simple
  things like `Style/StringLiterals` or the new
  `Lint/NonDeterministicRequireOrder`.