### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 3.1.0
 
 * Fix deprecation warning for AllCops/Excludes => AllCops/Exclude (#17)
 * Exclude `config.ru` from linter checks (#18)

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.0.0"
+  spec.version       = "3.1.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
- Excluding more files from the default linting checks and fix a deprecation warning.