### PR TITLE
Exclude `tmp` directory from linting checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Exclude `tmp` directory from linting checks
+
 # 3.1.0
 
 * Fix deprecation warning for AllCops/Excludes => AllCops/Exclude (#17)

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - 'bin/**'
     - 'config.ru'
+    - 'tmp/**'
 
   DisplayCopNames:
     Description: 'Display cop names in offense messages'


### PR DESCRIPTION
- These exist in govuk-content-schemas and other apps. We don't need to
  lint them, as they're temporary or otherwise not required.