### PR TITLE
Configure new cops to silence RuboCop warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Configure new cops about hash styles
 * Exclude `tmp` directory from linting checks
 
 # 3.1.0

--- a/config/other-style.yml
+++ b/config/other-style.yml
@@ -380,3 +380,12 @@ Style/WhileUntilModifier:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
Related issue: https://github.com/rubocop-hq/rubocop/issues/7771
Closes https://github.com/alphagov/rubocop-govuk/issues/16

We should enable these cops until we have a good reason not to.