### PR TITLE
Exclude old rails migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Exclude Rails migrations from linting checks (#25)
+
 # 3.2.0
 
 * Configure new cops about hash styles (#24)

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -8,6 +8,7 @@ require: rubocop-rails
 AllCops:
   Exclude:
     - 'db/schema.rb'
+    - 'db/migrate/201*'
 
 Rails:
   Enabled: true


### PR DESCRIPTION
There's very little value in linting these, we probably don't care in most cases and in some cases the linter changes would involve actual behavioural changes that would be undesirable to add retroactively. (Only excluding 201* so that migrations created in 2020 are still linted.)