### PR TITLE
Remove unsafe style cops

### DIFF
--- a/config/other-excludes.yml
+++ b/config/other-excludes.yml
@@ -14,3 +14,10 @@ Bundler/DuplicatedGem:
 
 Style/FormatStringToken:
   Enabled: false
+
+# These can result in false positives
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false

--- a/config/other-style.yml
+++ b/config/other-style.yml
@@ -383,9 +383,3 @@ Style/FrozenStringLiteralComment:
 
 Style/HashEachMethods:
   Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true


### PR DESCRIPTION
This is a partial revert of dbc3bc0d. These cops can result in false positives (as we've seen in
search-api) as described here [1].

https://rubocop.readthedocs.io/en/latest/cops_style/#stylehashtransformkeys