### PR TITLE
Exclude /tmp directory

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - 'bin/**'
     - 'config.ru'
-    - 'tmp/**'
+    - 'tmp/**/*'
 
   DisplayCopNames:
     Description: 'Display cop names in offense messages'


### PR DESCRIPTION
Currently have an issue that `/tmp` isn't being excluded for more than one level. This should fix the errors we're getting on builds like this https://github.com/alphagov/govuk-user-reviewer/pull/385.