### PR TITLE
Revert "Remove unsafe style cops"

### DIFF
--- a/config/other-excludes.yml
+++ b/config/other-excludes.yml
@@ -14,10 +14,3 @@ Bundler/DuplicatedGem:
 
 Style/FormatStringToken:
   Enabled: false
-
-# These can result in false positives
-Style/HashTransformKeys:
-  Enabled: false
-
-Style/HashTransformValues:
-  Enabled: false

--- a/config/other-style.yml
+++ b/config/other-style.yml
@@ -383,3 +383,9 @@ Style/FrozenStringLiteralComment:
 
 Style/HashEachMethods:
   Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
As per the comment below, we believe we can safely benefit
from these cops, as it's possible to change our existing code
to be compatible with them, without compromising the behaviour
of that code.

This reverts commit 7d676d0715a71d0b9c50c8a25e7685cf228e1e07.