### PR TITLE
Add rubocop-rake with all defaults

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -22,3 +22,4 @@ inherit_from:
   - other-style.yml
   - other-metrics.yml
   - other-excludes.yml
+  - rake.yml

--- a/config/rake.yml
+++ b/config/rake.yml
@@ -1,0 +1,1 @@
+require: rubocop-rake

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", "0.80.1"
   spec.add_dependency "rubocop-rails", "~> 2"
+  spec.add_dependency "rubocop-rake", "~> 0.5.1"
   spec.add_dependency "rubocop-rspec", "~> 1.28"
 end


### PR DESCRIPTION
This adds a few extra cops from the rubocop-rake, which is maintained
by rubocop-hq. All the defaults seem to be reasonable:

  - Rake/ClassDefinitionInTask - makes them harder to find
  - Rake/Desc - we mostly do this already
  - Rake/DuplicateNamespace
  - Rake/DuplicateTask
  - Rake/MethodDefinitionInTask - top-level methods are bad