### PR TITLE
Disable pending cops by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.5.0
+
+* Disable pending cops by default (#37)
+
 # 3.4.0
 
 * Add rubocop-rake cops (#32)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: disable
   Exclude:
     - 'bin/**'
     - 'config.ru'

--- a/config/gds-ruby-styleguide.yml
+++ b/config/gds-ruby-styleguide.yml
@@ -104,7 +104,7 @@ Layout/SpaceInsideParens:
   Description: No spaces after ( or before ).
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Description: No hard tabs.
   Enabled: true
 

--- a/config/other-lint.yml
+++ b/config/other-lint.yml
@@ -34,10 +34,6 @@ Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
 
-Lint/EndBlock:
-  Description: 'END blocks should not be placed inside method definitions.'
-  Enabled: true
-
 Lint/EnsureReturn:
   Description: 'Never use return in an ensure block.'
   Enabled: true

--- a/config/other-style.yml
+++ b/config/other-style.yml
@@ -380,12 +380,3 @@ Style/WhileUntilModifier:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.4.0"
+  spec.version       = "3.5.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 13.0"
 
-  spec.add_dependency "rubocop", "0.81.0"
+  spec.add_dependency "rubocop", "0.82.0"
   spec.add_dependency "rubocop-rails", "~> 2"
   spec.add_dependency "rubocop-rake", "~> 0.5.1"
   spec.add_dependency "rubocop-rspec", "~> 1.28"


### PR DESCRIPTION
Closes https://github.com/alphagov/rubocop-govuk/issues/35

Previously we had to explicitly configure pending cops to avoid CLI
warnings. In general we (try to) accept the RuboCop defaults, but
'pending' cops do not have a clear default behaviour. This ignores
all pending cops until they are enabled by default.

Note: this feature requires rubocop v0.82