### PR TITLE
Explain it all

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ inherit_from:
 inherit_mode:
   merge:
     - Exclude
+
+Rails:
+  Enabled: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,11 @@ library("govuk")
 
 node {
   govuk.buildProject(
-    sassLint: false
+    sassLint: false,
+    afterTest: {
+      stage("Check documentation") {
+        sh("bundle exec rake explain_yourself")
+      }
+    }
   )
 }

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,27 @@
 require "bundler/gem_tasks"
 require "rubocop/rake_task"
 
-task default: [:rubocop]
+task default: %i[rubocop explain_yourself]
 
 RuboCop::RakeTask.new
+
+desc "Check for missing documentation"
+task :explain_yourself do
+  missing_comment_regex = /^\s*\n([A-Z][\w\/]+):/
+  config_files = Dir["config/*.yml"]
+
+  unexplained_cops = config_files.map do |file|
+    File.read(file).scan(missing_comment_regex)
+  end
+
+  unexplained_cops.flatten!
+  cops_exempt_from_explanation = %w(AllCops Rails)
+  unexplained_cops -= cops_exempt_from_explanation
+
+  if unexplained_cops.any?
+    puts "Missing comment/explanation for Cop(s):\n\n"
+    puts unexplained_cops
+    puts
+    abort "Exiting due to missing documentation"
+  end
+end

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,8 @@ AllCops:
     - 'bin/**'
     - 'config.ru'
     - 'tmp/**/*'
+    - 'db/schema.rb'
+    - 'db/migrate/201*'
 
   DisplayCopNames:
     Description: 'Display cop names in offense messages'

--- a/config/gds-ruby-styleguide.yml
+++ b/config/gds-ruby-styleguide.yml
@@ -2,243 +2,391 @@
 ## General
 ############
 
+# Part of the orignal GDS styleguide
+# "Use soft-tabs with a two-space indent."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/BlockAlignment:
   Description: 'Align block ends correctly.'
   Enabled: true
 
+# Part of the original GDS styleguide
+# "Indent when as deep as case."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/CaseIndentation:
   Description: Indentation of when in a case/when/[else/]end.
   Enabled: true
   EnforcedStyle: case
-  SupportedStyles:
-  - case
-  - end
   IndentOneStep: false
 
+# TODO: unclear why this is here!
+# https://github.com/alphagov/govuk-lint/pull/38
 Layout/ClosingParenthesisIndentation:
   Description: 'Checks the indentation of hanging closing parentheses.'
   Enabled: false
 
+# TODO: unclear why this is here!
+# TODO: remove, as enabled by default!
 Style/MutableConstant:
   Description: 'Freeze mutable objects assigned to constants.'
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Use soft-tabs with a two-space indent."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use empty lines between defs and to break up a method into logical paragraphs."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
 Layout/EmptyLineBetweenDefs:
   Description: Use empty lines between defs.
   Enabled: true
   AllowAdjacentOneLineDefs: false
 
+# Part of the orignal GDS styleguide
+# "Never leave trailing whitespace"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/EmptyLines:
   Description: "Don't use several empty lines in a row."
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Use soft-tabs with a two-space indent."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Never leave trailing whitespace"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use soft-tabs with a two-space indent."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/IndentationWidth:
   Description: Use 2 spaces for indentation.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use soft-tabs with a two-space indent."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/IndentationConsistency:
   Description: Keep indentation straight.
   Enabled: true
 
+# https://github.com/alphagov/govuk-lint/pull/7
+# "There are occasions where following this rule forces you to make the
+# code less readable. This is particularly the case for tests where method
+# names form the test descriptions. Keeping test descriptions under a
+# certain length can force them to become cryptic."
 Layout/LineLength:
   Description: Limit lines to 80 characters.
   Enabled: false
-  Max: 80
 
- # Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use spaces around operators"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceAroundOperators:
   Description: Use spaces around operators.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use spaces [...] around {"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceBeforeBlockBraces:
   Description: Checks that the left block brace has or doesn't have space before it.
   Enabled: true
   EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use spaces [...] after semicolons"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceAfterSemicolon:
   Description: Use spaces after semicolons.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use spaces [...] after colons"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceAfterColon:
   Description: Use spaces after colons.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use spaces [...] after commas"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceAfterComma:
   Description: Use spaces after commas.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "No spaces after [...] [ or before ]"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceInsideReferenceBrackets:
   Description: No spaces after array[ or before ].
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "No spaces after [...] [ or before [...] ]"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceInsideArrayLiteralBrackets:
   Description: No spaces after array = [ or before ].
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "No spaces after ( [...] or before [...] )"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceInsideParens:
   Description: No spaces after ( or before ).
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Use soft-tabs with a two-space indent."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/IndentationStyle:
   Description: No hard tabs.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Never leave trailing whitespace"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/TrailingWhitespace:
   Description: Avoid trailing whitespace.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Never leave trailing whitespace"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/TrailingEmptyLines:
   Description: Checks trailing blank lines and final newline.
   Enabled: true
   EnforcedStyle: final_newline
-  SupportedStyles:
-  - final_newline
-  - final_blank_line
 
 ## Syntax
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Always use && and || for logic"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/AndOr:
   Description: Use &&/|| instead of and/or.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use def with parentheses when there are arguments"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/DefWithParentheses:
   Description: Use def with parentheses when there are arguments.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Never use for"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/For:
   Description: Checks use of for or each in multiline loops.
   Enabled: true
   EnforcedStyle: each
-  SupportedStyles:
-  - for
-  - each
 
+# https://github.com/alphagov/govuk-lint/pull/36
+# "When we have sequence of if/unless statements,
+# some with multiple lines within the if statement
+# block and some with a single line, forcing the single
+# line statements to re-written makes it a harder
+# to follow the branching logic."
 Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   Enabled: false
 
+# Part of the orignal GDS styleguide
+# "Never chain do...end"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
 Style/MethodCalledOnDoEndBlock:
   Description: Avoid chaining a method call on a do...end block.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Omit the parentheses when the method doesn’t accept any arguments"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
 Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Never chain do...end"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/MultilineBlockChain:
   Description: Avoid multi-line chains of blocks.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Never use then for multi-line if/unless"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/MultilineIfThen:
   Description: Never use then for multi-line if/unless.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Avoid the ternary operator [...]"
+# "However, do use the ternary operator [...]"
+# "for single line conditionals"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/MultilineTernaryOperator:
   Description: 'Avoid multi-line ?: (the ternary operator); use if/unless instead.'
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "ternary operators must not be nested"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/NestedTernaryOperator:
   Description: Use one expression per branch in a ternary operator.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Avoid the ternary operator [...]
+# However, do use the ternary operator [...]
+# for single line conditionals"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Don’t use parentheses around the condition of an
+# if/unless/while unless the condition contains an assignment"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/ParenthesesAroundCondition:
   Description: Don't use parentheses around the condition of an if/unless/while.
   Enabled: true
   AllowSafeAssignment: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Avoid return where not required"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/RedundantReturn:
   Description: Don't use return where it's not required.
   Enabled: true
   AllowMultipleReturnValues: false
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Never put a space between a method name and the opening parenthesis"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Layout/SpaceAfterMethodName:
   Description: Never put a space between a method name and the opening parenthesis in
     a method definition.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use spaces around the = operator when assigning default values to method parameters"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Layout/SpaceAroundEqualsInParameterDefault:
   Description: Checks that the equals signs in parameter default assignments have or
     don't have surrounding space depending on configuration.
   Enabled: true
   EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
 
+# Part of the orignal GDS styleguide
+# "Never use unless with else. Rewrite these with the positive case first"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Style/UnlessElse:
   Description: Never use unless with else. Rewrite these with the positive case first.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use _ for unused block parameters"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+# TODO: remove, as enabled by default!
 Lint/UnusedBlockArgument:
   Description: Checks for unused block arguments.
   Enabled: true
 
 ## Naming
 
+# Part of the orignal GDS styleguide
+# "Use CamelCase for classes and modules."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
+# TODO: remove, as enabled by default!
 Naming/ClassAndModuleCamelCase:
   Description: Use CamelCase for classes and modules.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use def self.method to define singleton methods.
+# This makes the methods more resistant to refactoring changes."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#classes
+# TODO: remove, as enabled by default!
 Style/ClassMethods:
   Description: Use self when defining module/class methods.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Avoid the usage of class (@@) variables"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#classes
+# TODO: remove, as enabled by default!
 Style/ClassVars:
   Description: Avoid the use of class variables.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Use SCREAMING_SNAKE_CASE for other constants."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
+# TODO: remove, as enabled by default!
 Naming/ConstantName:
   Description: Constants should use SCREAMING_SNAKE_CASE.
   Enabled: true
 
+# Part of the orignal GDS styleguide
+# "Use snake_case for methods and variables."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
+# TODO: remove, as enabled by default!
 Naming/MethodName:
   Description: Use the configured style when naming methods.
   Enabled: true
   EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Avoid get/set method names: these are better
+# implemented using Ruby's assignment syntax sugar.
+# Use attr_reader, attr_writer, and attr_accessor
+# for simple instance variable accessors."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
+# TODO: remove, as enabled by default!
 Style/TrivialAccessors:
   Description: Prefer attr_* methods to trivial readers/writers.
   Enabled: true
@@ -264,73 +412,95 @@ Style/TrivialAccessors:
   - to_s
   - to_sym
 
+# Part of the orignal GDS styleguide
+# "Use snake_case for methods and variables."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
+# TODO: remove, as enabled by default!
 Naming/VariableName:
   Description: Use the configured style when naming variables.
   Enabled: true
   EnforcedStyle: snake_case
-  SupportedStyles:
-  - snake_case
-  - camelCase
 
 ## Exceptions
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Avoid rescuing the Exception class."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#exceptions
+# TODO: remove, as enabled by default!
 Lint/RescueException:
   Description: Avoid rescuing the Exception class.
   Enabled: true
 
 ## Collections
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Instead of wrapping a long list of array
+# elements to a newline, write one element per line.
+# This enhances readability and helps generate clearer diffs."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
+# TODO: remove, as enabled by default!
 Layout/ArrayAlignment:
   Description: Align the elements of an array literal if they span more than one line.
   Enabled: true
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Use Ruby 1.9 syntax for symbolic hash keys.
+# This includes method calls."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
 Style/HashSyntax:
-  Description: 'Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax { :a => 1,
-    :b => 2 }.'
-  Enabled: true
   Exclude:
   - 'db/schema.rb'
 
-  EnforcedStyle: ruby19
-  SupportedStyles:
-  - ruby19
-  - hash_rockets
-
+# Part of the orignal GDS styleguide
+# "Add a trailing comma to multi-line array [...]
+# for clearer diffs with less line noise."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
 Style/TrailingCommaInArrayLiteral:
-  Enabled: true
   EnforcedStyleForMultiline: comma
 
+# Part of the orignal GDS styleguide
+# "Add a trailing comma to multi-line hash definitions [...]
+# for clearer diffs with less line noise."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
 Style/TrailingCommaInHashLiteral:
-  Enabled: true
   EnforcedStyleForMultiline: comma
 
+# Part of the orignal GDS styleguide
+# "When long lists of method arguments require
+# breaking over multiple lines, break each successive
+# argument on a new line, including the first argument
+# and closing paren. The final argument should include
+# a trailing comma."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
 Style/TrailingCommaInArguments:
-  Enabled: true
   EnforcedStyleForMultiline: comma
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Prefer %w to the literal array syntax when you need
+# an array of strings."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
 Style/WordArray:
-  Description: Use %w or %W for arrays of words.
-  Enabled: true
   MinSize: 0
 
+# TODO: unclear why this is here!
+# https://github.com/alphagov/govuk-lint/commit/5e42ec5690e3d4cc8fff44d0b0268c8e581c423a
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
 ## Strings
 
-# Supports --auto-correct
+# Part of the orignal GDS styleguide
+# "Prefer string interpolation instead of string concatenation"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#strings
+# TODO: remove, as enabled by default!
 Lint/RedundantStringCoercion:
   Description: Checks for Object#to_s usage in string interpolation.
   Enabled: true
 
-# Previously we had inconsistent uses of quotes
-# between repos, between files, and often within
-# the same file. This is unnecessarily confusing
-# flexibility that we don't want to allow.
+# "Try not to mix up single-quoted and double-quoted
+# strings within a file: it can make the code harder to read.
+# Definitely don't mix up single-quoted and double-quoted
+# strings within a method. If in doubt, use double-quoted strings,
+# because you’ll probably need to use interpolation somewhere.
 Style/StringLiterals:
-  Enabled: true
   EnforcedStyle: double_quotes

--- a/config/gds-ruby-styleguide.yml
+++ b/config/gds-ruby-styleguide.yml
@@ -327,11 +327,10 @@ Lint/RedundantStringCoercion:
   Description: Checks for Object#to_s usage in string interpolation.
   Enabled: true
 
-# Supports --auto-correct
+# Previously we had inconsistent uses of quotes
+# between repos, between files, and often within
+# the same file. This is unnecessarily confusing
+# flexibility that we don't want to allow.
 Style/StringLiterals:
-  Description: Checks if uses of quotes match the configured preference.
   Enabled: true
   EnforcedStyle: double_quotes
-  SupportedStyles:
-  - single_quotes
-  - double_quotes

--- a/config/other-excludes.yml
+++ b/config/other-excludes.yml
@@ -1,7 +1,3 @@
-AllCops:
-  Exclude:
-    - db/schema.rb
-
 Metrics/BlockLength:
   Enabled: true
   Exclude:

--- a/config/other-excludes.yml
+++ b/config/other-excludes.yml
@@ -1,3 +1,11 @@
+# Introduced in: 195e1d6934e610efed35151cfe90b01b805d7581
+# Introduced in: b7a98b43a4b0644b8d4ac40aa3ddaf35f06fa58f
+# "Many test frameworks use blocks for the entire test
+# case in a file as well as for individual tests within the file.
+# It's not unusual for a test case to be several lines
+# longer than the upper limit of the BlockLength cop,
+# and there's very little we can do to avoid that so
+# there's no point running this cop on our tests."
 Metrics/BlockLength:
   Enabled: true
   Exclude:
@@ -5,8 +13,26 @@ Metrics/BlockLength:
     - "**/spec/**/*"
   ExcludedMethods: ["namespace"]
 
+# Introduced in: 278fc6e903834acfb37565795a196b85282560b0
+# "A common pattern in our Gemfiles is to declare a gem
+# differently if we're in a dev mode or not. For example
+#
+# if ENV['API_DEV']
+#   gem 'gds-api-adapters', path: '../gds-api-adapters'
+# else
+#   gem 'gds-api-adapters', "~> 50.8.0"
+# end"
+# TODO: see if we can remove this (no longer valid??)
 Bundler/DuplicatedGem:
   Enabled: false
 
+# Introduced in: 5ca6b7d20fd62a6ce890868abdeca12837e436d7
+# "The wording of the description is hard to understand - it's not
+# immediately obvious what you have to do, and doesn't really say why
+# this is a good thing.
+#
+# It's not auto-fixable, which means it takes a lot of time to get the
+# syntax right for every occurrence of `%.2f` for example (taken from
+# `smart-answers`) for not very much benefit."
 Style/FormatStringToken:
   Enabled: false

--- a/config/other-lint.yml
+++ b/config/other-lint.yml
@@ -1,125 +1,210 @@
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/AmbiguousOperator:
   Description: >-
      Checks for ambiguous operators in the first argument of a
      method invocation without parentheses.
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/AmbiguousRegexpLiteral:
   Description: >-
     Checks for ambiguous regexp literals in the first argument of
     a method invocation without parenthesis.
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Layout/ConditionPosition:
   Description: 'Checks for condition placed in a confusing position relative to the keyword.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/Debugger:
   Description: 'Check for debugger calls.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/DeprecatedClassMethods:
   Description: 'Check for deprecated class method calls.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/EnsureReturn:
   Description: 'Never use return in an ensure block.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/SuppressedException:
   Description: "Don't suppress exception."
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/LiteralAsCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/LiteralInInterpolation:
   Description: 'Checks for literals used in interpolation.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/Loop:
   Description: >-
      Use Kernel#loop with break rather than begin/end/until or
      begin/end/while for post-loop tests.
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/ParenthesesAsGroupedExpression:
   Description: >-
      Checks for method calls with a space before the opening
      parenthesis.
   Enabled: true
 
+# Introduced in: 7b3d9f8ddcfe76477258216cbb1f259a579a778d
+# "A comma in a word array caused a subtle bug in Publisher:
+# alphagov/publisher#615"
+# TODO: remove, as enabled by default!
 Lint/PercentStringArray:
   Description: Checks for unwanted commas and quotes in %w/%W literals eg %w('foo', “bar”).
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/RequireParentheses:
   Description: >-
      Use parentheses in the method call to avoid confusion
      about precedence.
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/ShadowingOuterLocalVariable:
   Description: >-
      Do not use the same name as outer local variable
      for block arguments or block local variables.
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Layout/SpaceBeforeFirstArg:
   Description: >-
      Put a space between a method name and the first argument
      in a method call without parentheses.
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UnreachableCode:
   Description: 'Unreachable code.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UselessComparison:
   Description: 'Checks for comparison of something with itself.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
 
+# Unnecessary: 3cc7240d3456844b4c2f364d5933eee3a86417fb
+# "Enable all the lint checks"
+# TODO: remove, as enabled by default!
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: true

--- a/config/other-metrics.yml
+++ b/config/other-metrics.yml
@@ -1,11 +1,31 @@
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/AbcSize:
   Enabled: false
 
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/ClassLength:
   Enabled: false
 
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/ModuleLength:
   Enabled: false
 
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/PerceivedComplexity:
   Enabled: false

--- a/config/other-style.yml
+++ b/config/other-style.yml
@@ -1,56 +1,85 @@
+# Part of the orignal GDS styleguide
+# "Outdent private etc"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#classes
 Layout/AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.
   Enabled: true
   EnforcedStyle: outdent
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: conflicts with the original GDS styleguide
+# "Avoid get/set method names"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Alias:
   Description: 'Use alias_method instead of alias.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/HashAlignment:
   Description: >-
     Align the elements of a hash literal if they span more than
     one line.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/ParameterAlignment:
   Description: >-
     Align the parameters of a method call if they span more
     than one line.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/ArrayJoin:
   Description: 'Use Array#join instead of Array#*.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/AsciiComments:
   Description: 'Use only ascii symbols in comments.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Attr:
   Description: 'Checks for uses of Module#attr.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/BeginBlock:
   Description: 'Avoid the use of BEGIN blocks.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/BlockComments:
   Description: 'Do not use block comments.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/BlockDelimiters:
   Description: >-
     Avoid using {...} for multi-line blocks (multiline chaining is
@@ -58,225 +87,357 @@ Style/BlockDelimiters:
     Prefer {...} over do...end for single-line blocks.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/CharacterLiteral:
   Description: 'Checks for uses of character literals.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
   Enabled: false
 
+# TODO: duplicate (other-metrics.yml), remove
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
   Enabled: false
 
+# TODO: unclear why this is here!
+# TODO: remove, as disabled by default
 Style/CollectionMethods:
   Description: 'Preferred collection methods.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/CommentAnnotation:
   Description: >-
     Checks formatting of special comments
     (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'
   Enabled: false
 
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/CyclomaticComplexity:
   Description: 'Avoid complex methods.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/PreferredHashMethods:
   Description: 'Checks for use of deprecated Hash methods.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# Documenting every class is a lot of effort and we don't
+# expect to get any value from this. Another risk of adding
+# more documentation is the potential for confusion if that
+# documentation gets out-of-sync with the class/module.
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
+# Part of the original GDS styleguide
+# "leave one blank line before the visibility modifier
+# and one blank line below in order to emphasize that
+# it applies to all methods below it"
+# TODO: remove, as enabled by default!
 Layout/EmptyLinesAroundAccessModifier:
   Description: "Keep blank lines around access modifiers."
   Enabled: true
 
+# TODO: conflicts with gds-ruby-styleguide.rake!
+# Layout/EmptyLines:
+#  Description: "Don't use several empty lines in a row."
+#  Enabled: true
 Layout/EmptyLines:
   Description: "Keeps track of empty lines around expression bodies."
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/EmptyLiteral:
   Description: 'Prefer literals to Array.new/Hash.new/String.new.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Encoding:
   Description: 'Use UTF-8 as the source file encoding.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/EndBlock:
   Description: 'Avoid the use of END blocks.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/EvenOdd:
   Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Naming/FileName:
   Description: 'Use snake_case for source file names.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Lint/FlipFlop:
   Description: 'Checks for flip flops'
   Enabled: false
 
+# TODO: duplicate (other-excludes.yml), remove
 Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# This can lead to excessively long lines. Consistent with
+# disabling "Layout/LineLength".
+#
+# "There are occasions where following this rule forces you to make the
+# code less readable."
 Style/GuardClause:
   Description: 'Check for conditionals that can be replaced with guard clauses'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/IfWithSemicolon:
   Description: 'Never use if x; .... Use the ternary operator instead.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here! Suggest enabling this with
+# "EnforcedStyle: consistent".
 Layout/FirstArrayElementIndentation:
   Description: >-
     Checks the indentation of the first element in an array
     literal.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here! Suggest enabling this with
+# "EnforcedStyle: consistent".
 Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Lambda:
   Description: 'Use the new lambda literal syntax for single-line blocks.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/LeadingCommentSpace:
   Description: 'Comments should start with a space.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/LineEndConcatenation:
   Description: >-
     Use \ instead of + or << to concatenate two string literals at
     line end.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/MethodDefParentheses:
   Description: >-
     Checks if the method definitions have or don't have
     parentheses.
   Enabled: false
 
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/ModuleFunction:
   Description: 'Checks for usage of `extend self` in modules.'
   Enabled: false
 
+# Introduced in: 9b2a744ab119d7797aaf423abcec914360f4208e
+# "More lenient on multi-line operations"
+# TODO: unclear why this is here!
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/NegatedIf:
   Description: >-
     Favor unless over if for negative conditions
     (or control flow or).
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/NegatedWhile:
   Description: 'Favor until over while for negative conditions.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Next:
   Description: 'Use `next` to skip iteration instead of a condition at the end.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/NilComparison:
   Description: 'Prefer x.nil? to x == nil.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/NonNilCheck:
   Description: 'Checks for redundant nil checks.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Not:
   Description: 'Use ! instead of not.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/NumericLiterals:
   Description: >-
     Add underscores to large numeric literals to improve their
     readability.
   Enabled: false
 
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/PercentLiteralDelimiters:
   Description: 'Use `%`-literal delimiters consistently'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/PerlBackrefs:
   Description: 'Avoid Perl-style regex back references.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Proc:
   Description: 'Use proc instead of Proc.new.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here! Suggest enabling with
+# "EnforcedStyle: compact"
 Style/RaiseArgs:
   Description: 'Checks the arguments passed to raise/fail.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/RedundantBegin:
   Description: "Don't use begin blocks when they are not needed."
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/RedundantException:
   Description: "Checks for an obsolete RuntimeException argument in raise/fail."
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/RedundantSelf:
   Description: "Don't use self where it's not needed."
   Enabled: false
 
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Style/RegexpLiteral:
   Description: >-
     Use %r for regular expressions matching more than
@@ -285,56 +446,90 @@ Style/RegexpLiteral:
     `MaxSlashes` '/' character.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
   Enabled: false
 
+# Introduced in: 7aaebf4dbdf2a8d677b4000d3cd3512d4fb91e99
+# "This is a relatively new Ruby feature and is not mentioned in the Style
+# guide, so this commit disables it by default."
+# TODO: unclear why this is here!
 Style/SafeNavigation:
   Description: >-
     This cop transforms usages of a method call safeguarded by a check for the
     existance of the object to safe navigation (`&.`).
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/SelfAssignment:
   Description: 'Checks for places where self-assignment shorthand should have been used.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/Semicolon:
   Description: "Don't use semicolons to terminate expressions."
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/SignalException:
   Description: 'Checks for proper usage of fail and raise.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
+# TODO: remove, as disabled by default!
 Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here! Suggest enabling with
+# "AllowIfMethodIsEmpty: true" to accommodate Rails actions.
 Style/SingleLineMethods:
   Description: 'Avoid single-line methods.'
   Enabled: false
 
+# TODO: conflicts with other-lint.yml!
+# Layout/SpaceBeforeFirstArg:
+# Description: >-
+#     Put a space between a method name and the first argument
+#     in a method call without parentheses.
+#  Enabled: true
 Layout/SpaceBeforeFirstArg:
   Description: >-
     Checks that exactly one space is used between a method name
     and the first argument for method calls without parentheses.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/SpaceAroundKeyword:
   Description: 'Use spaces after if/elsif/unless/while/until/case/when.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/SpaceAfterNot:
   Description: Tracks redundant space after the ! operator.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Layout/SpaceBeforeComment:
   Description: >-
     Checks for missing space between code and a comment on the
     same line.
   Enabled: false
 
+# Part of the original GDS styleguide
+# "Use spaces [...] around { and before }"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceInsideBlockBraces:
   Description: >-
     Checks that block braces have or don't have surrounding space.
@@ -342,41 +537,63 @@ Layout/SpaceInsideBlockBraces:
     or doesn't have trailing space.
   Enabled: true
 
+# Part of the original GDS styleguide
+# "Use spaces [...] around { and before }"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+# TODO: remove, as enabled by default!
 Layout/SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."
   Enabled: true
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/RedundantCapitalW:
   Description: 'Checks for %W when interpolation is not needed.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/CommandLiteral:
   Description: 'Checks for %x when `` would do.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/VariableInterpolation:
   Description: >-
     Don't interpolate global, instance and class variables
     directly in strings.
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/WhenThen:
   Description: 'Use when x then ... for one-line cases.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/WhileUntilDo:
   Description: 'Checks for redundant do after while or until.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Style/WhileUntilModifier:
   Description: >-
     Favor modifier while/until usage when you have a
     single-line body.
   Enabled: false
 
+# Introduced in: b171d652d3e434b74ddc621df3b5be24c49bc7e8
+# This cop was added in preperation for a Ruby feature
+# that is no longer likely to become part of the language.
+# https://github.com/rubocop-hq/rubocop/issues/7197
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -13,34 +13,50 @@ AllCops:
 Rails:
   Enabled: true
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/HasAndBelongsToMany:
   Description: 'Prefer has_many :through to has_and_belongs_to_many.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/ReadWriteAttribute:
   Description: 'Checks for read_attribute(:attr) and write_attribute(:attr, val).'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/ScopeArgs:
   Description: 'Checks the arguments of ActiveRecord scopes.'
   Enabled: false
 
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# TODO: unclear why this is here!
 Rails/Validation:
   Description: 'Use sexy validations.'
   Enabled: false
 
+# Introduced in: 91d7bf4895db12727582ad7bf47bdcb20ab178f7
+# TODO: unclear (in any real detail) why this is here!
 Rails/SkipsModelValidations:
   Description: 'Avoid methods that skip model validations.'
   Enabled: false


### PR DESCRIPTION
    This adds documentation to explain the origin of all the config we
    have, which is now required by a 'explain_yourself' rake task.
    
    Each item of config has a reference to its origin, which is either
    the original GDS styleguide, or a particular commit. Although we
    could use the git history to track down a particular item of config,
    this has become quite hard in many cases, due to shifting config.
    
    Many items of config have 'TODO' recommendations, where the config
    is unnecessary (we're not in the business of specifying every single
    piece of config RuboCop supports), or I've been unable to find any
    explanation for its presence. Although it's not ideal to document
    config as 'unclear', this still represents knowledge that required
    effort to obtain, and will help someone auditing in future.

Please see the commits for more details.

Items of future work:

- [ ] Various PRs to debate various explanations
- [ ] A PR to remove all the redundant config
- [ ] A PR to reorganise the config by 'department'