### PR TITLE
Add missing 'inherit_mode' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Inherit rules from the gem by adding the following to your project's RuboCop con
 ```yaml
 # .rubocop.yml
 inherit_gem:
-  rubocop-govuk: 
+  rubocop-govuk:
     - config/default.yml
 ```
 
@@ -25,14 +25,18 @@ or if you also need Rails specific rules:
 ```yaml
 # .rubocop.yml
 inherit_gem:
-  rubocop-govuk: 
+  rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+
+inherit_mode:
+  merge:
+    - Exclude
 ```
 
 ## Usage
 
-Run RuboCop: 
+Run RuboCop:
 
 ```sh
 bundle exec rubocop


### PR DESCRIPTION
This is required if an app includes the 'default' and the 'rails'
config, since both define a set of 'AllCops' excludes that need to
be merged. In general, this also prevents surprising behaviour when
adding any other exclusions for individual apps.