### PR TITLE
Make sure we're testing config for 'rake'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
+# Run with all config to check it's valid
 inherit_from:
   - ./config/default.yml
   - ./config/rails.yml
+  - ./config/rake.yml
 
-AllCops:
-  Exclude:
-    - tmp/**/*
+inherit_mode:
+  merge:
+    - Exclude


### PR DESCRIPTION
This updates the '.rubocop.yml' file so that all config in this
repo is tested as part of the build. It also adds a comment to
explain the presence of otherwise non-applicable config, and removes
a redundant exclusion for 'tmp', which is covered by our config.