### PR TITLE
ci: Add GitHub Actions to run tests on every PR and push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: rubocop-govuk
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    - name: Install dependencies
+      run: |
+        gem install bundler
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
- Apart from the master build (which pushes the release tag and causes a
  gem publish), this doesn't need to run on our CI Jenkinses.
- Adding the master build (when this "test" job succeeds, only on
  master, run a "publish" job that pushes a release tag and builds and
  publishes the gem) is an exercise for the next person!