### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.6.0
+
+* Remove config that matches RuboCop defaults (#47)
+* Reorganise all the Cops (#44)
+
 # 3.5.0
 
 * Disable pending cops by default (#37)

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.5.0"
+  spec.version       = "3.6.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
Although much has changed in the repo, the net effect should be
non-breaking. This release should only have the effect of enabling
two Cops, which were previously disabled due to faulty config [1].

- Layout/EmptyLines
- Layout/SpaceBeforeFirstArg

[1]: https://github.com/alphagov/rubocop-govuk/pull/44