### PR TITLE
Add explanation for Metrics/BlockNesting

### DIFF
--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -46,7 +46,9 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 # Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
-# TODO: unclear why this is here!
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   Enabled: false


### PR DESCRIPTION
This persists with the current disabling of this Cop. In general, it's
unclear why a particular level of nesting (3?, 4?, 5?) is 'bad'.