### PR TITLE
Revisit our config for 'Naming' Cops

### DIFF
--- a/config/naming.yml
+++ b/config/naming.yml
@@ -1,9 +1,16 @@
+# Conflicts with the original GDS styleguide
+#
+# While this may conflict with the original GDS styleguide, there
+# are times where we wish to call a method that "sets" something.
+#
+# def set_political_and_government(edition)
+#
+# The original styleguide only accounts for a specific kind of "set"
+# operation, where the argument is the value being assigned.
+#
 # Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
-# TODO: conflicts with the original GDS styleguide
-# "Avoid get/set method names"
 # https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
 Naming/AccessorMethodName:
-  Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 
 # Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429

--- a/config/naming.yml
+++ b/config/naming.yml
@@ -15,18 +15,6 @@ Naming/AccessorMethodName:
 
 # Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
 # TODO: unclear why this is here!
-Naming/AsciiIdentifiers:
-  Description: 'Use only ascii symbols in identifiers.'
-  Enabled: false
-
-# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
-# TODO: unclear why this is here!
-Naming/FileName:
-  Description: 'Use snake_case for source file names.'
-  Enabled: false
-
-# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
-# TODO: unclear why this is here!
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   Enabled: false


### PR DESCRIPTION
This has the effect of turning on two cops:

- Naming/AsciiIdentifiers
- Naming/FileName

Please see the commits for more details. Trying to enable Naming/PredicateName
uncovered quite a few issues, so I'm going to leave that one for now.