### PR TITLE
Bump version to 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.8.0
+
+* Enable check for flip-flops (#55)
+* Enable Layout/FirstArrayElementIndentation (#56)
+* Enable Layout/FirstHashElementIndentation (#56)
+* Enable Naming/AsciiIdentifiers (#58)
+* Enable Naming/FileName (#58)
+* Enable Rails/ActionFilter (#59)
+* Enable Rails/ScopeArgs (#59)
+
 # 3.7.0
 
 * Turn a load of Cops back on (#52)

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.7.0"
+  spec.version       = "3.8.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
Previously we merged a few PRs that each turn on one or two Cops. This
bumps the version to avoid accruing a backlog that makes it impractical
to address all the issues in the resulting Dependabot PRs.