### PR TITLE
Enable Cops to enforce consistent multiline style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+* Enable Layout/MultilineArrayLineBreaks (#63)
+* Enable Layout/MultilineHashKeyLineBreaks (#63)
+* Enable Layout/MultilineMethodArgumentLineBreaks (#63)
+* Enable 	Layout/FirstMethodArgumentLineBreak (#63)
+
 # 3.9.0
 
 * Enable Style/Alias (#60)

--- a/config/layout.yml
+++ b/config/layout.yml
@@ -72,3 +72,31 @@ Layout/FirstHashElementIndentation:
 # Introduced in: 9b2a744ab119d7797aaf423abcec914360f4208e
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+# We should be consistent: if some items of an array are
+# on multiple lines, then all items should be. This works
+# better with the indentation Cops, produces clearer diffs,
+# and avoids wasting time tweaking an arbitrary layout.
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+# We should be consistent: if some items of a hash are
+# on multiple lines, then all items should be. This works
+# better with the indentation Cops, produces clearer diffs,
+# and avoids wasting time tweaking an arbitrary layout.
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+
+# We should be consistent: if some items of a method call are
+# on multiple lines, then all items should be. This works
+# better with the indentation Cops, produces clearer diffs,
+# and avoids wasting time tweaking an arbitrary layout.
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
+
+# We should put each argument of a method call on a new line,
+# if any are on new lines. This prevents unnecessary decisions
+# about which style to use; the multiline style also helps to
+# avoid excessively long lines.
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true


### PR DESCRIPTION
Previously we had a variety of styles for multiline arrays, hashes
and method calls. This enables a few Cops that will help us avoid
repetitive stylistic decisions about otherwise arbitrary layout.

All these Cops support auto-correct, and testing against Whitehall,
Smart Answers, Content Publisher and Government Frontend shows a
general increase in consistency, such as the following example:

      - 2013-01-03 2013-01-17 2013-01-31 2013-02-14 2013-02-28
      - 2013-03-14 2013-03-28 2013-04-11 2013-04-25 2013-05-09
      - 2013-05-23 2013-06-06 2013-06-20 2013-07-04 2013-07-18
      - 2013-08-01 2013-08-15 2013-08-29 2013-09-12 2013-09-26
      + 2013-01-03
      + 2013-01-17
      + 2013-01-31
      + 2013-02-14