### PR TITLE
Ignore vendor and node_modules directories

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'tmp/**/*'
     - 'db/schema.rb'
     - 'db/migrate/201*'
+    - 'vendor/**/*'
 
   DisplayCopNames:
     Description: 'Display cop names in offense messages'

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'db/schema.rb'
     - 'db/migrate/201*'
     - 'vendor/**/*'
+    - 'node_modules/**/*'
 
   DisplayCopNames:
     Description: 'Display cop names in offense messages'


### PR DESCRIPTION
These are both common places for third party code to exist which shouldn't be linted.