### PR TITLE
Actually disable Metrics/BlockLength

### DIFF
--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -7,12 +7,7 @@
 # have long blocks by convention (tests, config, rake tasks,
 # gemspecs), to the point where its value is dubious.
 Metrics/BlockLength:
-  Enabled: true
-  Exclude:
-    - test/**/*
-    - "**/spec/**/*"
-    - config/routes.rb
-  ExcludedMethods: ["namespace"]
+  Enabled: false
 
 # Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
 # "Disable opinionated cops"


### PR DESCRIPTION
This got missed in https://github.com/alphagov/rubocop-govuk/pull/65.