### PR TITLE
Import config for rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 inherit_from:
   - ./config/default.yml
   - ./config/rails.yml
-  - ./config/rake.yml
+  - ./config/rspec.yml
 
 inherit_mode:
   merge:

--- a/config/capybara.yml
+++ b/config/capybara.yml
@@ -1,0 +1,5 @@
+# Within GOV.UK we use Capybara test method syntax of feature,
+# scenario. We don't want this outside of feature specs though.
+Capybara/FeatureMethods:
+  Exclude:
+    - 'spec/features/**/*.rb'

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,0 +1,37 @@
+require: rubocop-rspec
+
+inherit_from:
+  - capybara.yml
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+RSpec/ExampleLength:
+  Enabled: false
+
+# We have common cases, such as rake tasks, where we do not
+# use a class to the describe the test.
+RSpec/DescribeClass:
+  Enabled: false
+
+# We accept multiple expectations (within reason), preferring
+# them to running mulitple similar tests.
+RSpec/MultipleExpectations:
+  Enabled: false
+
+# Part of the GOV.UK feature style involves instance variables.
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/features/**/*.rb'
+
+# In GOV.UK we quite often test that a class received a method.
+RSpec/MessageSpies:
+  Enabled: false
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+RSpec/NestedGroups:
+  Enabled: false


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

This adds the config used for rubocop-rspec in Content Publisher.
We only use rubocop-rspec in one other repo - asset-manager - but
the large number of unexplained overrides eans its config is not
viable to import, although should be broadly compatible with this.