### PR TITLE
Disable Layout/FirstMethodArgumentLineBreak again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unversioned
+
+- Disable Layout/FirstMethodArgumentLineBreak (#79)
+
 # 3.12.0
 
 - Disable Rails/HasAndBelongsToMany (#77)

--- a/config/layout.yml
+++ b/config/layout.yml
@@ -90,10 +90,3 @@ Layout/MultilineHashKeyLineBreaks:
 # and avoids wasting time tweaking an arbitrary layout.
 Layout/MultilineMethodArgumentLineBreaks:
   Enabled: true
-
-# We should put each argument of a method call on a new line,
-# if any are on new lines. This prevents unnecessary decisions
-# about which style to use; the multiline style also helps to
-# avoid excessively long lines.
-Layout/FirstMethodArgumentLineBreak:
-  Enabled: true


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/pull/63#issuecomment-631683298

Previously we enabled this to try and bring consistency to repos
where auto-correct for other Cops was struggling due to the high
variation in layout we have in our repos. However, enabling this
Cop has lead to new layout issues with hanging brackets:

  Mailer.deliver(
      to: 'bob@example.com',
      from: 'us@example.com',
      subject: 'Important message',
      body: source.text)

This disables the Cop again, since enabling it contradicts the Ruby
styleguide [1], and has made layout harder to visually paerse in
some cases, which was not the original intention.

[1]: https://rubystyle.guide/#no-double-indent