### PR TITLE
Disable Layout/MultilineMethodArgumentLineBreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unversioned
 
 - Disable Layout/FirstMethodArgumentLineBreak (#79)
+- Disable Layout/MultilineMethodArgumentLineBreaks (#80)
 
 # 3.12.0
 

--- a/config/layout.yml
+++ b/config/layout.yml
@@ -83,10 +83,3 @@ Layout/MultilineArrayLineBreaks:
 # and avoids wasting time tweaking an arbitrary layout.
 Layout/MultilineHashKeyLineBreaks:
   Enabled: true
-
-# We should be consistent: if some items of a method call are
-# on multiple lines, then all items should be. This works
-# better with the indentation Cops, produces clearer diffs,
-# and avoids wasting time tweaking an arbitrary layout.
-Layout/MultilineMethodArgumentLineBreaks:
-  Enabled: true


### PR DESCRIPTION
Previously we enabled this Cop to bring more consistency to our
method calls, for which we have a variety of styles across our repos.
While array and hash items are often uniform in nature, this Cop had
undesirable outcomes for method calls with complex arguments [1].

The vertical overlap of arguments and array items makes them harder to
visually parse, compared to the original.

     +      build(:document_type,
     +            tags: [primary_organisation_field,
     +                   organisations_field,
     +                   role_appointments_field])

vs.

     +      build(:document_type, tags: [primary_organisation_field,
                                         organisations_field,
                                         role_appointments_field])

[1]: https://github.com/alphagov/rubocop-govuk/pull/63#issuecomment-632002471