### PR TITLE
Disable Layout/MultilineMethodArgumentLineBreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unversioned
 
+- Disable Layout/MultilineMethodArgumentLineBreaks (#80)
 - Disable Layout/FirstMethodArgumentLineBreak (#79)
 
 # 3.12.0

--- a/config/layout.yml
+++ b/config/layout.yml
@@ -83,10 +83,3 @@ Layout/MultilineArrayLineBreaks:
 # and avoids wasting time tweaking an arbitrary layout.
 Layout/MultilineHashKeyLineBreaks:
   Enabled: true
-
-# We should be consistent: if some items of a method call are
-# on multiple lines, then all items should be. This works
-# better with the indentation Cops, produces clearer diffs,
-# and avoids wasting time tweaking an arbitrary layout.
-Layout/MultilineMethodArgumentLineBreaks:
-  Enabled: true


### PR DESCRIPTION
This cop is being disabled as it is one that deviates from the Rubocop
defaults and does not uniformly produce code that we can agree is
better.

The full backstory and discussion surrounding this removal is in
https://github.com/alphagov/rubocop-govuk/pull/63.

In a nutshell though, this cop offers a somewhat opinionated approach to
writing methods which conflicts with common idiomatic approaches such
as:

```
        gds_user = build(:user, permissions: [
          User::ACCESS_LIMIT_OVERRIDE_PERMISSION,
        ])
```

which then needs to be-rewritten as:

```
        gds_user = build(:user,
                         permissions: [
                           User::ACCESS_LIMIT_OVERRIDE_PERMISSION,
                         ])
```

which is less concise and less conventional with common GOV.UK patterns.