### PR TITLE
Disable Rails/DynamicFindBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unversioned
+
+- Disable Rails/DynamicFindBy
+
 # 3.14.0
 
 - Disable Rails/InverseOf

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -13,6 +13,17 @@ AllCops:
 Rails:
   Enabled: true
 
+# We have custom find_by methods in several repos, which
+# we're not going to rename. This Cop also raises false
+# positives for find_by methods that are unrelated to model
+# classes, as well as for repos using Mongoid. The value
+# of the consistency this brings is limited, since we mostly
+# use find_by(key: value) anyway.
+#
+# https://github.com/rubocop-hq/rubocop/issues/3758
+Rails/DynamicFindBy:
+  Enabled: false
+
 # We commonly print output in Ruby code that has been
 # extracted from a Rake task in 'lib/'.
 Rails/Output:


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

The auto-correct for this Cop is unsafe, including for in-built
ActiveRecord methods that have no keyword args alternative. Repos
that have manual overrides for this include:

- Content Data Admin
- Travel Advice Publisher
- Manuals Publisher
- Content Publisher
- Content Store
- Publisher
- Content Tagger
- Email Alert API
- Whitehall
- Finder Frontend