### PR TITLE
Tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,39 @@ Add `rubocop-govuk` to your Gemfile and then run `bundle install`:
 gem 'rubocop-govuk'
 ```
 
-Inherit rules from the gem by adding the following to your project's RuboCop config:
+Then inherit the default rules by adding the following in your project:
 
 ```yaml
 # .rubocop.yml
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
-```
-
-or if you also need Rails specific rules:
-
-```yaml
-# .rubocop.yml
-inherit_gem:
-  rubocop-govuk:
-    - config/default.yml
-    - config/rails.yml
 
 inherit_mode:
   merge:
     - Exclude
 ```
 
-## Usage
+You can also configure additional rules for Rails and RSpec:
 
-Run RuboCop:
-
-```sh
-bundle exec rubocop
+```yaml
+# .rubocop.yml
+inherit_gem:
+  rubocop-govuk:
+    ...
+    - config/rails.yml
 ```
+
+```yaml
+# .rubocop.yml
+inherit_gem:
+  rubocop-govuk:
+    ...
+    - config/rspec.yml
+```
+
+## Testing
+
+Run `bundle exec rake`.
 
 [guides]: https://github.com/alphagov/styleguides


### PR DESCRIPTION
This makes a few changes:

- Recommend using exclusive merge in general, since it's not specific
to Rails Cops
- Indicate that config for RSpec Cops is available, as well as for Rails
- Update the 'build' command, since we now use 'rake' instead of
  'rubocop' directly