### PR TITLE
Remove redundant cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unversioned
 
+- Remove cops that are RuboCop defaults (#88)
 - Disable Rails/DynamicFindBy
 
 # 3.14.0

--- a/config/layout.yml
+++ b/config/layout.yml
@@ -1,10 +1,3 @@
-# Part of the orignal GDS styleguide
-# "Use empty lines between defs and to break up a method into logical paragraphs."
-# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
-Layout/EmptyLineBetweenDefs:
-  Enabled: true
-  AllowAdjacentOneLineDefs: false
-
 # https://github.com/alphagov/govuk-lint/pull/7
 # "There are occasions where following this rule forces you to make the
 # code less readable. This is particularly the case for tests where method

--- a/config/style.yml
+++ b/config/style.yml
@@ -14,12 +14,6 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
 # Part of the orignal GDS styleguide
-# "Omit the parentheses when the method doesn’t accept any arguments"
-# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: true
-
-# Part of the orignal GDS styleguide
 # "Use Ruby 1.9 syntax for symbolic hash keys.
 # This includes method calls."
 # https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections

--- a/config/style.yml
+++ b/config/style.yml
@@ -139,11 +139,6 @@ Style/RegexpLiteral:
 Style/SafeNavigation:
   Enabled: false
 
-# We should allow for single line empty methods, as this
-# is a convention for Rails controller actions.
-Style/SingleLineMethods:
-  AllowIfMethodIsEmpty: true
-
 # Introduced in: b171d652d3e434b74ddc621df3b5be24c49bc7e8
 # This cop was added in preperation for a Ruby feature
 # that is no longer likely to become part of the language.

--- a/config/style.yml
+++ b/config/style.yml
@@ -14,14 +14,6 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 
 # Part of the orignal GDS styleguide
-# "Use Ruby 1.9 syntax for symbolic hash keys.
-# This includes method calls."
-# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
-Style/HashSyntax:
-  Exclude:
-  - 'db/schema.rb'
-
-# Part of the orignal GDS styleguide
 # "Add a trailing comma to multi-line array [...]
 # for clearer diffs with less line noise."
 # https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections


### PR DESCRIPTION
This removes a number of cops that aren't necessary as they don't deviate from rubocops defaults. I tried this out on Content Publisher and Whitehall and saw no new issues raised by this.

I also wondered if we should remove https://github.com/alphagov/rubocop-govuk/blob/edfe29f067ecd0890a95ee07e65fe84936a8cded/config/style.yml#L54-L59
Since this only differs from the rubocop defaults by applying it at lengths < 1. Arguably the most surprising occurrence of our cop is when it tells you to change `["item"]` into %w[item]`. I decided against doing this on this PR as it would have an affect unlike the other ones.