### PR TITLE
Lock dependencies to their full versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.16.0
+
+- Bump and lock rubocop-rails to 2.6.0
+- Bump and lock rubocop-rspec to 1.39.0
+
 # 3.15.0
 
 - Remove cops that are RuboCop defaults (#88)

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.15.0"
+  spec.version       = "3.16.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
Previously we only specified higher order versions for some of the
dependencies of this repo, which lead to varying versions being
used downstream, and a lack of DependaBot PRs because there's no
corresponding lockfile to record the version bump. This specifies
the full version of each dependent gem, except for dev dependencies.