### PR TITLE
Revert "Update rubocop-rails requirement from = 2.6.0 to = 2.7.0"

### DIFF
--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13"
 
   spec.add_dependency "rubocop", "0.87.1"
-  spec.add_dependency "rubocop-rails", "2.7.0"
+  spec.add_dependency "rubocop-rails", "2.6.0"
   spec.add_dependency "rubocop-rake", "0.5.1"
   spec.add_dependency "rubocop-rspec", "1.42.0"
 end


### PR DESCRIPTION
Reverts alphagov/rubocop-govuk#100

I accidentally merged this in, but I don't think we'll want this until #98 has been released, sorry @benthorner!