### PR TITLE
Pin rubocop-ast to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.17.1
+
+- Pin rubocop-ast to 0.8.0
+
 # 3.17.0
 
 - Enable Rails/SaveBang

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.17.0"
+  spec.version       = "3.17.1"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13"
 
   spec.add_dependency "rubocop", "0.87.1"
+  spec.add_dependency "rubocop-ast", "0.8.0"
   spec.add_dependency "rubocop-rails", "2.8.1"
   spec.add_dependency "rubocop-rake", "0.5.1"
   spec.add_dependency "rubocop-rspec", "1.42.0"


### PR DESCRIPTION
Otherwise this leads to different linting errors depending on the
version present on each machine [1].

[1]: https://github.com/alphagov/govuk_app_config/pull/161/commits/985cfdb78eeda13054793e4802a13f6781c4731a