### PR TITLE
Fixes rubocop-rails deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.17.2
+
+- Rename Blacklist to ForbiddenMethods to fix rubocop-rails warnings
+
 # 3.17.1
 
 - Pin rubocop-ast to 0.8.0

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -36,7 +36,7 @@ Rails/Output:
 # no efficient alternative. Instead, we should only enable
 # this Cop for methods that have a clear alternative.
 Rails/SkipsModelValidations:
-  Blacklist:
+  ForbiddenMethods:
     - update_attribute
 
 # While using has_many/through does have some advantages,

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "3.17.1"
+  spec.version       = "3.17.2"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
Fixes the following deprecation warning:

```bash
bundle exec rake
Running RuboCop...
Warning: Rails/SkipsModelValidations does not support Blacklist parameter.

Supported parameters are:

  - Enabled
  - ForbiddenMethods
  - AllowedMethods
```

See https://github.com/rubocop-hq/rubocop-rails/pull/265 and https://github.com/alphagov/rubocop-govuk/pull/112