### PR TITLE
Add require: false to the readme in line with rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add `rubocop-govuk` to your Gemfile and then run `bundle install`:
 
 ```ruby
 # Gemfile
-gem 'rubocop-govuk'
+gem 'rubocop-govuk', require: false
 ```
 
 Then inherit the default rules by adding the following in your project:


### PR DESCRIPTION
Similar to https://github.com/rubocop-hq/rubocop-rspec/pull/859, this PR adds `require: false` to the readme.