### PR TITLE
Disable recently problematic rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Downgrade local Ruby version to `2.6.6` to capture lowest supported
   Ruby version
 - Fix namespace change of `Capybara/FeatureMethods`
+- Disable `Naming/VariableNumbers`
 
 # 3.17.2
 

--- a/config/naming.yml
+++ b/config/naming.yml
@@ -19,3 +19,10 @@ Naming/AccessorMethodName:
 # repos, which would require manual intervention.
 Naming/PredicateName:
   Enabled: false
+
+# This rule can cause readability issues when applied (for example
+# `born_on_or_before_6_april_1935` becomes `born_on_or_before_6april1935`)
+# and would require lots of amends to apply either `normalcase`
+# or `snake_case` to projects. It is not auto-correctable.
+Naming/VariableNumber:
+  Enabled: false

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -10,6 +10,11 @@ inherit_from:
 RSpec/ExampleLength:
   Enabled: false
 
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 # We have common cases, such as rake tasks, where we do not
 # use a class to the describe the test.
 RSpec/DescribeClass:


### PR DESCRIPTION
This is to follow https://github.com/alphagov/rubocop-govuk/pull/124 it disables two rules that prove problematic as a result of the dependency updates. This build will fail until #124 is merged and this is rebased onto it. Further details in the commits.