### PR TITLE
Rename release of 4.0.0.pre-1 to 4.0.0.pre.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.0.0.pre-1
+# 4.0.0.pre.1
 
 - Released as a pre-release to try surface any issues before wider rollout,
   use https://github.com/alphagov/rubocop-govuk/issues/129 to record any
@@ -17,6 +17,10 @@
   Ruby version
 - Fix namespace change of `Capybara/FeatureMethods`
 - Disable `Naming/VariableNumbers`
+
+# 4.0.0.pre.pre.1
+
+- Mistakenly named release, same as 4.0.0.pre.1
 
 # 3.17.2
 

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.0.0.pre-1"
+  spec.version       = "4.0.0.pre.1"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
It turns out naming this 4.0.0.pre-1 creates a release of 4.0.0.pre.pre.1 which is a bit weird.

I'll plan to yank the pre.pre.1 release once this is out.