### PR TITLE
Bump Rubocop gems and release rubocop-govuk 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.0.0
+
+- Update rubocop to 1.15.0
+- Update rubocop-ast to 1.6.0
+- Update rubocop-rails to 2.10.0
+- Update rubocop-rspec to 2.3.0
+
 # 4.0.0.pre.1
 
 - Released as a pre-release to try surface any issues before wider rollout,

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 13"
 
-  spec.add_dependency "rubocop", "~> 1.10.0"
-  spec.add_dependency "rubocop-ast", "~> 1.4.0"
-  spec.add_dependency "rubocop-rails", "~> 2.9.1"
+  spec.add_dependency "rubocop", "~> 1.15.0"
+  spec.add_dependency "rubocop-ast", "~> 1.6.0"
+  spec.add_dependency "rubocop-rails", "~> 2.10.0"
   spec.add_dependency "rubocop-rake", "0.5.1"
-  spec.add_dependency "rubocop-rspec", "~> 2.2.0"
+  spec.add_dependency "rubocop-rspec", "~> 2.3.0"
 end

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.0.0.pre.1"
+  spec.version       = "4.0.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This updates the Rubocop dependencies of this gem to the latest version. The impact of applying these to 4 apps (Content Publisher, Email Alert API, Smart Answers and Whitehall) was modest and convinced me there wasn't a need for another pre-release.

Thus, this also the release of rubocop-govuk 4.0