### PR TITLE
Pin exact versions of Rubocop gems

### DIFF
--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 13"
 
-  spec.add_dependency "rubocop", "~> 1.15.0"
-  spec.add_dependency "rubocop-ast", ">= 1.6", "< 1.12"
-  spec.add_dependency "rubocop-rails", ">= 2.10", "< 2.12"
+  spec.add_dependency "rubocop", "1.15.0"
+  spec.add_dependency "rubocop-ast", "1.11.0"
+  spec.add_dependency "rubocop-rails", "2.11.3"
   spec.add_dependency "rubocop-rake", "0.5.1"
-  spec.add_dependency "rubocop-rspec", ">= 2.3", "< 2.5"
+  spec.add_dependency "rubocop-rspec", "2.4.0"
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Cr2TnMtI/193-make-it-easier-to-agree-with-rubocop-govuk

Unfortunately using the pessimistic operator (~>, also known as
twiddle-waka) [1] for rubocop gem dependencies doesn't play nicely
with Dependabot. When these are used Dependabot will update the gemspec
to allow a range of gem versions. This is not ideal as it can mean that
different installations of rubocop-govuk may have different linting
rules (and for gem development there can be differences between local
installs and CI systems).

This change removes the ambiguous versioning and switches to the exact
version being defined again, as things were before
https://github.com/alphagov/rubocop-govuk/pull/124. The reason this was
changed previously was to allow bug fixes to rubocop dependencies to be
used without cutting a new gem.

This benefit however seems to be offset by the frustrations of the PR's
Dependabot opens being unsafe to merge directly.

For reference, Dependabot has a number of versioning strategies [2],
however when you have a pessimistic operator it seems to always end
up expanding the range as far as I can tell [3].

[1]: https://thoughtbot.com/blog/rubys-pessimistic-operator
[2]: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#versioning-strategy
[3]: https://github.com/dependabot/dependabot-core/blob/dd1fba76003434639209627676febc595787ba7c/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb#L78-L80