### PR TITLE
Release version 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 4.1.0
+
+- Update rubocop to 1.21.0
+- Update rubocop-ast to 1.11.0
+- Update rubocop-rails to 2.12.0
+- Update rubocop-rspec to 2.4.0
+- Update rubocop-rake to 0.6.0
+
 # 4.0.0
 
 - Update rubocop to 1.15.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.0.0"
+  spec.version       = "4.1.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This release contains updates of the various dependencies.

From my testing, the changes are relatively minor. Testing it on GOV.UK
repos, I've been able to apply this to the following without any
changes needed:

- smart-answers
- content-publisher
- email-alert-api
- search-api
- publisher

These repos have changes that can be resolved with `rubocop -A`:

- whitehall
- frontend

The common issue that I've seen in test cases is that Rubocop now
prefers `['Item A', 'Item B']` over `%W[Item\ A Item\ B]` - which seems
fair enough as the latter is a bit cryptic.