### PR TITLE
Release version 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.2.0
+
+- Update rubocop to 1.23.0
+- Update rubocop-ast to 1.13.0
+- Update rubocop-rails to 2.12.4
+- Update rubocop-rspec to 2.6.0
+
 # 4.1.0
 
 - Update rubocop to 1.21.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.1.0"
+  spec.version       = "4.2.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This releases routine updates of dependent gems.

This release has been tested against:

- Whitehall: 1 autocorrectable issue
- Content Publisher: No issues
- Search API:
- GDS API Adapters: 1 autocorrectable issue (from last release)