### PR TITLE
Prepare 4.3.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.3.0
+
+- Update rubocop to 1.25.0
+- Update rubocop-ast to 1.15.1
+- Update rubocop-rails to 2.13.2
+- Update rubocop-rspec to 2.7.0
+
 # 4.2.0
 
 - Update rubocop to 1.23.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.2.0"
+  spec.version       = "4.3.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This bumps the various rubocop gems.

I've run this release against whitehall, content-publisher, search-api
and gds-api-adapters. None of which had linting issues to resolve - so
this appears to be a quite benign release.