### PR TITLE
Update Rspec/ContextWording list

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -50,3 +50,5 @@ RSpec/ContextWording:
     - without
     - and
     - but
+    - before
+    - after


### PR DESCRIPTION
We are implementing the rubocop-govuk gem in a couple of repos and are having some linguistic issues with tests that exercise delayed jobs.  

We have a number of tests where the nested contexts are:
```ruby
context 'when submission errors' do
  context 'with a generic error' do
   	# setup
    context 'before the final retry' do
      # setup
      # test
    end
    context 'when the retry is at the max retries' do
      # setup
      # test
    end
  end
end
```
Rewording the tests in line with the required words (`and the final retry has not started`) makes them harder to understand!
As the [rubocop documenttation](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording) also lists `before` and `after` as acceptable prefixes, how do you feel about this extension?