### PR TITLE
Allow the GITHUB_TOKEN write permission on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
As of 1st February 2022, the org-wide setting for GitHub Actions has been hardened such that the GITHUB_TOKEN generated for each action run has just 'read' permission, and not 'read/write' as it previously had.

This means we have to explicitly grant 'write' permission to the deploy job so that it can tag new releases on the GitHub repository. This is achieved by adding a `permissions` key to the CI workflow configuration, as [described here][1].

[1]: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/