### PR TITLE
Update rubocop-govuk.gemspec

### DIFF
--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 13"
 
-  spec.add_dependency "rubocop", "1.27.0"
+  spec.add_dependency "rubocop", "1.28.0"
   spec.add_dependency "rubocop-ast", "1.17.0"
   spec.add_dependency "rubocop-rails", "2.14.2"
   spec.add_dependency "rubocop-rake", "0.6.0"


### PR DESCRIPTION
Bump Rubocop to 1.28 as it fixes a number of bugs with 1.27

https://github.com/rubocop/rubocop/releases/tag/v1.28.0