### PR TITLE
Bump to release 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.5.0
+
+- Update rubocop to 1.30.1
+- Update rubocop-ast to 1.18.0
+- Update rubocop-rspec to 2.11.1
+
 # 4.4.0
 
 - Update rubocop to 1.27.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.4.0"
+  spec.version       = "4.5.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This includes better compatibility with Ruby 3.1 due to https://github.com/rubocop/rubocop/issues/10359

This release has been tested against:

- Content Publisher - correctable [RSpec/ExpectChange](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange) issues 
- govuk_publishing_components - no issues
- Search API - no issues
- Whitehall - no issues