### PR TITLE
Bump to release 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.6.0
+
+- Update rubocop to 1.31.2
+- Update rubocop-ast to 1.19.1
+- Update rubocop-rails to 2.15.2
+- Update rubocop-rspec to 2.12.1
+
 # 4.5.0
 
 - Update rubocop to 1.30.1

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.5.0"
+  spec.version       = "4.6.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This releases updates for rubocop, rubocop-ast, rubocop-rails and
rubocop-rspec.

This release has been tested against:

- Whitehall - 1 correctable issue
- Content Publisher - no issues
- Search API - 1 correctable issue
- govuk_publishing_components - no issues