### PR TITLE
Bump to 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.7.0
+
+- Update rubocop to 1.35.0
+- Update rubocop-ast to 1.21.0
+
 # 4.6.0
 
 - Update rubocop to 1.31.2

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.6.0"
+  spec.version       = "4.7.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This releases updates for rubocop and rubocop-ast.

This release has been tested against:

Whitehall - no issues
Content Publisher - no issues
Search API - 1 correctable issue
gds-api-adapters - 1 correctable issue