### PR TITLE
Bump to 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.8.0
+
+- Update rubocop to 1.37.1
+- Update rubocop-ast to 1.23.0
+- Update rubocop-rails to 2.17.1
+- Update rubocop-rspec to 2.14.1
+
 # 4.7.0
 
 - Update rubocop to 1.35.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.7.0"
+  spec.version       = "4.8.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This releases updates to rubocop, rubocop-ast, rubocop-rails and rubocop-rspec.

Tested in:

- Whitehall - no issues
- Content Publisher - no issues
- Search API - 3 autocorrectable issues