### PR TITLE
Release version 4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.9.0
+
+- Update rubocop to 1.39.0
+- Update rubocop-rails to 2.17.3
+- Update rubocop-rspec to 2.15.0
+
 # 4.8.0
 
 - Update rubocop to 1.37.1

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.8.0"
+  spec.version       = "4.9.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This is a routine release that updates the rubocop, rubocop-rails and rubocop-rspec gems.

Runs:

- [Whitehall](https://github.com/alphagov/rubocop-govuk/actions/runs/3547961825#summary-9707114626) - 1 easy to fix violation
- [Content Publisher](https://github.com/alphagov/rubocop-govuk/actions/runs/3547962768#summary-9707117149) - 1 easy to fix violation
- [Search API](https://github.com/alphagov/rubocop-govuk/actions/runs/3547967368#summary-9707129416) - no violations
- [GDS API Adapters](https://github.com/alphagov/rubocop-govuk/actions/runs/3547968385#summary-9707131913) - no violations