### PR TITLE
Release 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.10.0
+
+- Update rubocop to 1.44.1
+- Update rubocop-ast to 1.24.1
+- Update rubocop-rails to 2.17.4
+- Update rubocop-rspec to 2.18.1
+
 # 4.9.0
 
 - Update rubocop to 1.39.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.9.0"
+  spec.version       = "4.10.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This is a routine release that updates the rubocop, rubocop-ast, rubocop-rails and rubocop-rspec gems.

I've run it against 4 repos:

- [Whitehall](https://github.com/alphagov/rubocop-govuk/actions/runs/4052781807#summary-10999292280) - 64 Style/HashSyntax violations, 1 Style/RedundantRegexpEscape violation - all autocorrectable
- [Content Publisher](https://github.com/alphagov/rubocop-govuk/actions/runs/4052785750#summary-10999301282) - 11 Style/HashSyntax violations, 1 Style/RedundantRegexpEscape - all autocorrectable
- [Search API](https://github.com/alphagov/rubocop-govuk/actions/runs/4052787264#summary-10999304824) - no violations
- [GDS API Adapters](https://github.com/alphagov/rubocop-govuk/actions/runs/4052788116#summary-10999307188) - no violations

It seems that Style/HashSyntax has got more sensitive, now picking up on methods without parenthesis, so this may cause a bit of churn in codebases. It is quickly fixed with autocorrect though.