### PR TITLE
Release version 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## Unreleased
+## 4.11.0
 
-* Drop support for Ruby 2.7.
+- Drop support for Ruby 2.7.
+- Update rubocop to 1.53.1
+- Update rubocop-ast to 1.29.0
+- Update rubocop-rails 2.20.2
+- Update rubocop-rake to 0.6.0
+- Update rubocop-rspec to 2.22.0
 
 # 4.10.0
 

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.10.0"
+  spec.version       = "4.11.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This release drops support for Ruby 2.7 (*breaking*) and also updates rubocop, rubocop-ast, rubocop-rails, rubocop-rake and rubocop-rspec. Summary of changes in [this diff](https://github.com/alphagov/rubocop-govuk/compare/c55d9f8a9b0693a0a4e6f93346e52362e4d43007..58b7f20640b4b68661f3771b0e803d83fc04ff12).

Tested against the following apps (following the precedent in #272):

- [Whitehall](https://github.com/alphagov/rubocop-govuk/actions/runs/5398651979/jobs/9804729806) ✅ 
- [Content Publisher](https://github.com/alphagov/rubocop-govuk/actions/runs/5398750820) 5 offences detected:
  - 4 `FactoryBot/CreateList` 'convention' violations ("Prefer `create_list`" where app has used for example `image_revisions: [create(:image_revision, filename: "960x640.jpg")],`)
    - Autocorrectable ✅ 
  - 1 `Lint/RedundantCopDisableDirective` 'warning' violation ("Unnecessary disabling of `Rails/CreateTableWithTimestamps`" for line `create_table :active_storage_variant_records do |t| # rubocop:disable Rails/CreateTableWithTimestamps`).
    - This appears to be down to [a change in rubocop-rails](https://github.com/rubocop/rubocop-rails/pull/1011) in [2.20.0](https://github.com/rubocop/rubocop-rails/blob/master/CHANGELOG.md#2200-2023-06-18)
- [Search API](https://github.com/alphagov/rubocop-govuk/actions/runs/5398752770) ✅ 
- [GDS API Adapters](https://github.com/alphagov/rubocop-govuk/actions/runs/5398753882) ✅ 