### PR TITLE
Bump to 4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.12.0
+
+- Update rubocop to 1.55.0
+
 ## 4.11.0
 
 - Drop support for Ruby 2.7.

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.11.0"
+  spec.version       = "4.12.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This has been tested against the following repos:

- [Whitehall][1] - no issues
- [Content Publisher][2] - no issues
- [Search API][3] - one easy to fix issue
- [GDS API Adapters][4] - no issues

[1]: https://github.com/alphagov/rubocop-govuk/actions/runs/5678303960
[2]: https://github.com/alphagov/rubocop-govuk/actions/runs/5678306445
[3]: https://github.com/alphagov/rubocop-govuk/actions/runs/5678308624
[4]: https://github.com/alphagov/rubocop-govuk/actions/runs/5678310619