### PR TITLE
Use GOV.UK conventions for running GitHub Action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,22 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        default: main
+        type: string
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref || github.ref }}
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true


### PR DESCRIPTION
This updates the approach to running this workflow to reflect the approach in: https://github.com/alphagov/govuk-developer-docs/pull/3961