### PR TITLE
Bump to 4.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.13.0
+
+- Update rubocop to 1.59.0
+- Update rubocop-ast to 1.30.0
+- Update rubocop-rails to 2.23.0
+- Update rubocop-rspec to 2.25.0
+
 ## 4.12.0
 
 - Update rubocop to 1.55.0

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.12.0"
+  spec.version       = "4.13.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This has been tested against the following repos:

- [Whitehall](https://github.com/alphagov/rubocop-govuk/actions/runs/7262725886)
- [Content Publisher](https://github.com/alphagov/rubocop-govuk/actions/runs/7263188706)
- [Search API](https://github.com/alphagov/rubocop-govuk/actions/runs/7263211264)
- [GDS API Adapters](https://github.com/alphagov/rubocop-govuk/actions/runs/7263237502)

They all have easy to fix issues.

[Trello card](https://trello.com/c/y0hcI72D/3370-cut-a-new-release-of-rubocop-govuk-2)