### PR TITLE
Extend feature spec exemptions to system specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Apply feature spec exemptions to system specs
+
 # 4.16.1
 
 * Update dependencies

--- a/config/capybara.yml
+++ b/config/capybara.yml
@@ -1,5 +1,6 @@
 # Within GOV.UK we use Capybara test method syntax of feature,
-# scenario. We don't want this outside of feature specs though.
+# scenario. We don't want this outside of feature or system specs though.
 RSpec/Capybara/FeatureMethods:
   Exclude:
     - 'spec/features/**/*.rb'
+    - 'spec/system/**/*.rb'

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -29,6 +29,7 @@ RSpec/MultipleExpectations:
 RSpec/InstanceVariable:
   Exclude:
     - 'spec/features/**/*.rb'
+    - 'spec/system/**/*.rb'
 
 # In GOV.UK we quite often test that a class received a method.
 RSpec/MessageSpies:


### PR DESCRIPTION
## Description 

RSpec recommends using system specs for feature testing.
See https://rspec.info/documentation/3.8/rspec-rails/#feature-specs

We use instance variables and scenarios for our feature specs. This commit applies the feature spec exemptions to system specs so our codebases are consistent

We've temporarily overwritten these rules in the govuk-chat repo but will remove them once this has been released.
