### PR TITLE
Add autorelease workflow

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,10 @@
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '00 13 * * 2'
+
+jobs:
+  autorelease:
+    uses: alphagov/govuk-infrastructure/.github/workflows/autorelease-rubygem.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
[Trello card](https://trello.com/c/bYVP288R/3447-5-automate-release-of-new-gem-versions)

Adds a scheduled workflow that runs every Tuesday at 1pm ([24 hours before the gem release alert tool](https://github.com/alphagov/gem-release-alert/blob/main/.github/workflows/version_checker.yml#L6)) to automatically raise a PR to bump the version if (and only if) all of the changes since the last release were made by Dependabot.