### PR TITLE
Bump version to 4.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.15.0
+
+- Update rubocop to 1.62.1
+- Update rubocop-ast to 1.31.2
+- Update rubocop-rails to 2.24.0
+- Update rubocop-rspec to 2.27.1
+
 ## 4.14.0
 
 - Update rubocop to 1.60.2

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.14.0"
+  spec.version       = "4.15.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
This should probably be a patch-level release, but I'm following the same convention as previous releases.