### PR TITLE
Disable `Style/MultilineBlockChain`

### DIFF
--- a/config/style.yml
+++ b/config/style.yml
@@ -153,3 +153,10 @@ Style/FrozenStringLiteralComment:
 # https://rubystyle.guide/#no-datetime
 Style/DateTime:
   Enabled: true
+
+# This rule conflicts with Style/BlockDelimiters.
+# Style/MultilineBlockChain says use do...end instead of {...} for multi-line blocks,
+# but Style/BlockDelimiters says use {...} instead of do...end when chaining.
+# The latter should take priority over the former, because it leads to more readable code.
+Style/MultilineBlockChain:
+  Enabled: false


### PR DESCRIPTION
 This rule conflicts with `Style/BlockDelimiters`:

* `Style/MultilineBlockChain` says use `do...end` instead of `{...}` for multi-line blocks, but
* `Style/BlockDelimiters` says use `{...}` instead of `do...end` when chaining.

The latter should take priority over the former, because it leads to more readable code.

## Example

Not allowed with `Style/MultilineBlockChain`:

```ruby
YAML.safe_load(commit_message)
  .fetch("updated-dependencies")
  .map { |dep|
    dependency = Dependency.new(dep["dependency-name"])
    type = Change.type_from_dependabot_type(dep["update-type"])
    Change.new(dependency, type)
  }
  .then { |changes| ChangeSet.new changes }
```

Not allowed with `Style/BlockDelimiters`:

```ruby
YAML.safe_load(commit_message)
  .fetch("updated-dependencies")
  .map do |dep|
    dependency = Dependency.new(dep["dependency-name"])
    type = Change.type_from_dependabot_type(dep["update-type"])
    Change.new(dependency, type)
  end
  .then { |changes| ChangeSet.new changes }
```

The former reads better than the latter, IMO