### PR TITLE
Update autorelease.yml

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,7 +1,10 @@
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: '00 13 * * 2'
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
   autorelease:


### PR DESCRIPTION
Run autorelease workflow when pull requests are merged into the main branch.

Running on a weekly schedule means there are often commits other than Dependabot ones and a PR to bump version will not be opened.