### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   push:
     branches:


### PR DESCRIPTION
govuk-dependabot-merger does not recognize the CI file if it's missing a name.