### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0
+
+- BREAKING: Update rubocop-rspec to 3.0 which enables by default previously pending cops. See [rubocop-rspec's changelog](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#300-2024-06-11) for details.
+
 # 4.18.0
 
 * Drop support for Ruby 3.0

--- a/config/capybara.yml
+++ b/config/capybara.yml
@@ -4,9 +4,3 @@ require: rubocop-capybara
 # scenario. 
 Capybara:
   Enabled: true
-
-# We don't want this cop outside of feature or system specs though.
-RSpec/Dialect:
-  Exclude:
-    - 'spec/features/**/*.rb'
-    - 'spec/system/**/*.rb'

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -51,3 +51,11 @@ RSpec/ContextWording:
     - without
     - and
     - but
+
+# Within GOV.UK we use Capybara test method syntax of feature,
+# scenario.
+# We don't want this cop outside of feature or system specs though.
+RSpec/Dialect:
+  Exclude:
+    - 'spec/features/**/*.rb'
+    - 'spec/system/**/*.rb'

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -56,6 +56,15 @@ RSpec/ContextWording:
 # scenario.
 # We don't want this cop outside of feature or system specs though.
 RSpec/Dialect:
+  # Disables all Capybara-specific methods that have the same native 
+  # RSpec method (e.g. are just aliases)
+  PreferredMethods:
+    background: :before
+    scenario:   :it
+    xscenario:  :xit
+    given:      :let
+    given!:     :let!
+    feature:    :describe
   Exclude:
     - 'spec/features/**/*.rb'
     - 'spec/system/**/*.rb'

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "4.18.0"
+  spec.version       = "5.0.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
We may want to do a pre release to update config for the new cops.

Tested against:
- ✅ [Whitehall](https://github.com/alphagov/rubocop-govuk/actions/runs/9566166969)
- ✅ [Frontend](https://github.com/alphagov/rubocop-govuk/actions/runs/9566270732)
- ✅ [Publisher](https://github.com/alphagov/rubocop-govuk/actions/runs/9566431667)
- ✅ [Search API](https://github.com/alphagov/rubocop-govuk/actions/runs/9566435170)
- ✅ [GDS API Adapters](https://github.com/alphagov/rubocop-govuk/actions/runs/9566438341)
- ❌  [Content Publisher](https://github.com/alphagov/rubocop-govuk/actions/runs/9566223199) - expected as this is a Breaking change*
- ❌ [Content Tagger](https://github.com/alphagov/rubocop-govuk/actions/runs/9611191083) - expected as this is a Breaking change*

*Failing with previously pending cops are now enabled by default: RSpec/BeEmpty, RSpec/BeEq, RSpec/BeNil, RSpec/ChangeByZero, RSpec/ClassCheck, RSpec/ContainExactly, RSpec/DuplicatedMetadata, RSpec/EmptyMetadata, RSpec/EmptyOutput, RSpec/Eq, RSpec/ExcessiveDocstringSpacing, RSpec/ExpectInLet, RSpec/IdenticalEqualityAssertion, RSpec/IndexedLet, RSpec/IsExpectedSpecify, RSpec/MatchArray, RSpec/MetadataStyle, RSpec/NoExpectationExample, RSpec/PendingWithoutReason, RSpec/ReceiveMessages, RSpec/RedundantAround, RSpec/RedundantPredicateMatcher, RSpec/RemoveConst, RSpec/RepeatedSubjectCall, RSpec/SkipBlockInsideExample, RSpec/SortMetadata, RSpec/SpecFilePathFormat, RSpec/SpecFilePathSuffix, RSpec/SubjectDeclaration, RSpec/UndescriptiveLiteralsDescription, and RSpec/VerifiedDoubleReference
