### PR TITLE
Disable RSpec/NoExpectationExample for feature/system specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.1
+
+- Disable RSpec/NoExpectationExample for feature and system specs as it false triggers.
+
 # 5.0.0
 
 - BREAKING: Update rubocop-rspec to 3.0 which enables by default previously pending cops. See [rubocop-rspec's changelog](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#300-2024-06-11) for details.

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -31,6 +31,13 @@ RSpec/InstanceVariable:
     - 'spec/features/**/*.rb'
     - 'spec/system/**/*.rb'
 
+# The GOV.UK Feature spec style has expectations in method calls so this
+# cop falsely triggers.
+RSpec/NoExpectationExample:
+  Exclude:
+    - 'spec/features/**/*.rb'
+    - 'spec/system/**/*.rb'
+
 # In GOV.UK we quite often test that a class received a method.
 RSpec/MessageSpies:
   Enabled: false
@@ -56,7 +63,7 @@ RSpec/ContextWording:
 # scenario.
 # We don't want this cop outside of feature or system specs though.
 RSpec/Dialect:
-  # Disables all Capybara-specific methods that have the same native 
+  # Disables all Capybara-specific methods that have the same native
   # RSpec method (e.g. are just aliases)
   PreferredMethods:
     background: :before

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "5.0.0"
+  spec.version       = "5.0.1"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
[The GOV.UK Rails convention approach for feature/system specs](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html#featuresystem-testing) have expectations within methods and thus falsely trigger this cop.

For example we think a test like this is valid:

```
  scenario do
    given_i_have_an_active_conversation_with_an_answered_question
    when_i_visit_the_conversation_page
    and_i_click_that_the_answer_was_useful
    then_i_see_that_my_feedback_was_submitted
  end

  def then_i_see_that_my_feedback_was_submitted
    expect(page).to have_content("Feedback submitted successfully.")
  end
```

Whereas this cop would trigger as there are no expectations in the
scenario.

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/rubocop-govuk/pull/381/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
