### PR TITLE
Update `require: rubocop-x` to `plugins: rubocop-x`

### DIFF
--- a/config/capybara.yml
+++ b/config/capybara.yml
@@ -1,4 +1,4 @@
-require: rubocop-capybara
+plugins: rubocop-capybara
 
 # Within GOV.UK we use Capybara test method syntax of feature,
 # scenario. 

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -3,7 +3,7 @@
 # By default Rails is switched off so this can be used by non-Rails apps,
 # this can be enabled in a local .rubocop.yml file
 
-require: rubocop-rails
+plugins: rubocop-rails
 
 AllCops:
   Exclude:

--- a/config/rake.yml
+++ b/config/rake.yml
@@ -1,1 +1,1 @@
-require: rubocop-rake
+plugins: rubocop-rake

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,4 +1,4 @@
-require: rubocop-rspec
+plugins: rubocop-rspec
 
 inherit_from:
   - capybara.yml


### PR DESCRIPTION
This removes the migration warnings when running rubocop

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/rubocop-govuk/pull/381/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
