### PR TITLE
Release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.1.0
+
+* Migrate to the plugin system
+* Update rubocop-ast from 1.38.1 to 1.39.0
+
 # 5.0.11
 
 * Update dependencies

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "5.0.11"
+  spec.version       = "5.1.0"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/rubocop-govuk/pull/381/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
