### PR TITLE
Release v5.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.6
+
+* Update dependencies
+
 # 5.1.5
 
 * Update dependencies

--- a/rubocop-govuk.gemspec
+++ b/rubocop-govuk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-govuk"
-  spec.version       = "5.1.5"
+  spec.version       = "5.1.6"
   spec.authors       = ["Government Digital Service"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
 


### PR DESCRIPTION
For gds-api-adapters, rubocop 1.75.3 had a breaking change. This was fixed in https://github.com/rubocop/rubocop/pull/14110 and released in 1.75.4. Therefore releasing the upgraded rubocop-govuk manually to unblock the upgrade in gds-api-adapters