### PR TITLE
Exclude tests from helper instance variable rule

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -92,3 +92,11 @@ Rails/SaveBang:
 # about whether we mean 'Time[.zone].now'.
 Rails/TimeZone:
   EnforcedStyle: "strict"
+
+# This rule to avoid using instance variables in helpers
+# is over aggressive and is catching helper tests and helpers specs
+# as well. Minitests that don't use the Rspec let convention need
+# instance variables to do the testing. Excluding them from the rule.
+Rails/HelperInstanceVariable:
+  Exclude:
+    - '**/*_test.rb'


### PR DESCRIPTION
This rule is breaking for Helper Tests, which are not helper themselves. The tests (specifically minitests) use instance variables for testing, since they don't have let syntax like rspec. This rule should exclude these files.

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/rubocop-govuk/pull/381/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
