### PR TITLE
Rename cop PredicateName to PredicatePrefix

### DIFF
--- a/config/naming.yml
+++ b/config/naming.yml
@@ -17,7 +17,7 @@ Naming/AccessorMethodName:
 # At the time of writing, this Cop is not auto-correctable, and
 # would generate a prohibitively high number of issues across our
 # repos, which would require manual intervention.
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 # This rule can cause readability issues when applied (for example


### PR DESCRIPTION
Rename cop PredicateName to PredicatePrefix

Inline with warnings

```
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .../gems/rubocop-govuk-5.1.13/config/naming.yml, please update it)
```

⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/rubocop-govuk/pull/381/files) after merging your changes. ⚠️

Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.
